### PR TITLE
chore: revert from subtle_ng to subtle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 [dependencies]
 blst = { version = "=0.3.7", default-features = true }
 rand_core = "0.6"
-ff = { git = "https://github.com/davidrusu/ff.git", branch="switch-to-subtle-ng"} # "0.11"
-group = { git = "https://github.com/davidrusu/group.git", branch="switch-to-subtle-ng", features = ["tests"] } # version = "0.11", features = ["tests"] }
-pairing_lib = { git = "https://github.com/davidrusu/pairing", branch="switch-to-subtle-ng", package = "pairing"  } # { version = "0.21", package = "pairing" }
-subtle = { package = "subtle-ng", version="2.2.1" }
+ff = "0.11.0"
+group = {version = "0.11.0", features = ["tests"]}
+pairing_lib = {package = "pairing", version = "0.21.0"}
+subtle = "2.4.1"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 ec-gpu = { version = "0.1.0", optional = true }


### PR DESCRIPTION
We again use the standard, published versions of:
 ff, group, pairing, subtle

all tests are passing.

```
test result: ok. 115 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 132.89s
```